### PR TITLE
Add tap gesture handlers and improve interaction in InfiniteCanvasViewer

### DIFF
--- a/example/lib/editor.dart
+++ b/example/lib/editor.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:infinite_canvas_viewer/infinite_canvas_viewer.dart';
 
 class Item extends Equatable {
@@ -58,6 +59,12 @@ class _CanvasState extends State<Editor> {
   Widget build(BuildContext context) {
     return InfiniteCanvasViewer(
       controller: _controller,
+      backgroundColor: Colors.white,
+      gridType: GridType.dot,
+      canPan: true,
+      onTapOutside: () {},
+      onDoubleTap: () {},
+      onLongPress: () {},
       children: items
           .mapIndexed(
             (index, item) => RectTransform(
@@ -65,6 +72,7 @@ class _CanvasState extends State<Editor> {
               angle: item.angle,
               onNewBounds: (bounds, angle) =>
                   _handleNewBounds(index, bounds, angle),
+              onTapInside: () {},
               child: Container(color: item.color),
             ),
           )

--- a/lib/canvas/canvas_layout.dart
+++ b/lib/canvas/canvas_layout.dart
@@ -176,7 +176,9 @@ class CanvasLayoutRenderBox extends RenderBox
             return child!.hitTest(result, position: transformed);
           },
         );
-        if (isHit) return true;
+        if (isHit) {
+          return true;
+        }
       }
       child = childParentData.previousSibling;
     }

--- a/lib/rect_transform/rect_transform.dart
+++ b/lib/rect_transform/rect_transform.dart
@@ -25,7 +25,6 @@ class RectTransform extends StatefulWidget {
     this.onNewBounds,
     this.onTransformEnd,
     this.onTapInside,
-    this.onTapOutside,
   }) : assert(
          (bounds != null) ||
              (position != null && scale != null && baseSize != null),
@@ -65,8 +64,7 @@ class RectTransform extends StatefulWidget {
   final Function(Offset, double, Offset)? onNewTransform;
   final Function(Rect, double)? onNewBounds;
   final VoidCallback? onTransformEnd;
-  final Function(PointerDownEvent)? onTapInside;
-  final Function(PointerDownEvent)? onTapOutside;
+  final VoidCallback? onTapInside;
 
   @override
   State<RectTransform> createState() => _RectTransformState();
@@ -196,9 +194,8 @@ class _RectTransformState extends State<RectTransform> {
         position.dx * widget.worldScale - kPadding,
         position.dy * widget.worldScale - kPadding,
       ),
-      child: TapRegion(
-        onTapInside: (event) => widget.onTapInside?.call(event),
-        onTapOutside: (event) => widget.onTapOutside?.call(event),
+      child: GestureDetector(
+        onTap: () => widget.onTapInside?.call(),
         child: Transform.rotate(
           angle: angle,
           child: SizedBox(


### PR DESCRIPTION
- Replaced current Tap interactions with GestureDetector for wider range of interactions
- onTapOutside replaced from the item's widget to the canvas widget
- onTapOutside now does not get triggered when tapped on an item
- Fixed the bug where onTapInside and onTapOutside were getting overlapped in case of multiple children on canvas